### PR TITLE
Memorize axis attribute "range"

### DIFF
--- a/sardana_albaem/ctrl/Albaem2CoTiCtrl.py
+++ b/sardana_albaem/ctrl/Albaem2CoTiCtrl.py
@@ -75,7 +75,7 @@ class Albaem2CoTiCtrl(CounterTimerController):
         "Range": {
             Type: str,
             Description: 'Range for the channel',
-            Memorize: NotMemorized,
+            Memorize: Memorized,
             Access: DataAccess.ReadWrite,
         },
         "Inversion": {


### PR DESCRIPTION
Memorize the axis attribute "range" because otherwise in the case that the ALBA Electrometer is restarted this attribute is lost. (CSBL-6511)